### PR TITLE
Dev/gui/product list UI rework - Product list button replaced by a link

### DIFF
--- a/src/gui/resources/ProductList.qml
+++ b/src/gui/resources/ProductList.qml
@@ -32,11 +32,11 @@ Frame {
                 font.bold: true
                 font.pointSize: 12
 
-                color: inspecctProductlink.containsMouse ? "blue" : "black"
-                font.underline: inspecctProductlink.containsMouse
+                color: inspectProductlink.containsMouse ? "blue" : "black"
+                font.underline: inspectProductlink.containsMouse
 
                 MouseArea {
-                    id: inspecctProductlink
+                    id: inspectProductlink
                     anchors.fill: parent
                     cursorShape: Qt.PointingHandCursor
                     hoverEnabled: true

--- a/src/gui/resources/ProductList.qml
+++ b/src/gui/resources/ProductList.qml
@@ -23,6 +23,7 @@ Frame {
             width: parent.width
 
             Text {
+                id: idField
                 Layout.alignment: Qt.AlignLeft
                 Layout.minimumWidth: parent.width * 0.07
 
@@ -30,6 +31,19 @@ Frame {
                 horizontalAlignment: Text.AlignHCenter
                 font.bold: true
                 font.pointSize: 12
+
+                MouseArea{
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+
+                    onClicked: {
+                        productPageLoader.source = ""
+
+                        productPageLoader.productId = model.ID
+                        productPageLoader.source = "ProductWindow.qml"
+                    }
+                }
             }
 
             Text {

--- a/src/gui/resources/ProductList.qml
+++ b/src/gui/resources/ProductList.qml
@@ -46,17 +46,6 @@ Frame {
                 color: "#383737"
                 font.pointSize: 9
             }
-
-            Button {
-                text: "inspect"
-
-                onClicked: {
-                    productPageLoader.source = ""
-
-                    productPageLoader.productId = model.ID
-                    productPageLoader.source = "ProductWindow.qml"
-                }
-            }
         }
     }
 }

--- a/src/gui/resources/ProductList.qml
+++ b/src/gui/resources/ProductList.qml
@@ -32,7 +32,11 @@ Frame {
                 font.bold: true
                 font.pointSize: 12
 
-                MouseArea{
+                color: inspecctProductlink.containsMouse ? "blue" : "black"
+                font.underline: inspecctProductlink.containsMouse
+
+                MouseArea {
+                    id: inspecctProductlink
                     anchors.fill: parent
                     cursorShape: Qt.PointingHandCursor
                     hoverEnabled: true


### PR DESCRIPTION
Product details panel is now accessible by pressing a link.
For now only ID acts as a link (it's a 64 bit integer, should be long enough to press easily).

#### If the link turns out to be to hard to use, the hover area can be extended to both name and description field.