### PR TITLE
Dev/gui/convert product instance model to use vector

### DIFF
--- a/src/gui/ProductInstanceModel.cpp
+++ b/src/gui/ProductInstanceModel.cpp
@@ -27,11 +27,11 @@ QVariant ProductInstanceModel::data(const QModelIndex &index, int role) const
     // Return placeholder data
     if(role == IdRole)
     {
-        return QVariant(index.row());
+        return QVariant(productInstances[index.row()].getId());
     }
     if(role == LocationRole)
     {
-        return QVariant("Example Location");
+        return QVariant(QString::fromStdString(productInstances[index.row()].getLocationId()));
     }
 
     return QVariant();

--- a/src/gui/ProductInstanceModel.cpp
+++ b/src/gui/ProductInstanceModel.cpp
@@ -15,8 +15,7 @@ int ProductInstanceModel::rowCount(const QModelIndex &parent) const
         return 0;
     }
 
-    constexpr auto hardocedNumOfElements = 10u;
-    return hardocedNumOfElements;
+    return productInstances.size();
 }
 
 QVariant ProductInstanceModel::data(const QModelIndex &index, int role) const

--- a/src/gui/ProductInstanceModel.cpp
+++ b/src/gui/ProductInstanceModel.cpp
@@ -3,7 +3,7 @@
 ProductInstanceModel::ProductInstanceModel(QObject *parent)
     : QAbstractListModel{parent}
 {
-
+    // TODO: Get productInstances from core throug getProductInstanceByProductId [not available now]
 }
 
 int ProductInstanceModel::rowCount(const QModelIndex &parent) const
@@ -23,7 +23,6 @@ QVariant ProductInstanceModel::data(const QModelIndex &index, int role) const
     if(!index.isValid())
         return QVariant();
 
-    // Return placeholder data
     if(role == IdRole)
     {
         return QVariant(productInstances[index.row()].getId());

--- a/src/gui/ProductInstanceModel.hpp
+++ b/src/gui/ProductInstanceModel.hpp
@@ -2,6 +2,11 @@
 
 #include <QAbstractListModel>
 
+#include <vector>
+
+#include "core/Core.hpp"
+#include "common/productInstance.hpp"
+
 class ProductInstanceModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -19,4 +24,8 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
     virtual QHash<int, QByteArray> roleNames() const override;
+
+private:
+    std::vector<bakcyl::common::ProductInstance> productInstances;
+
 };


### PR DESCRIPTION
Product Instance model, responsible for managing product instance listView, now uses vectors to store data ans is therefore compatible with core.