### PR TITLE
Dev/gui/connect product list to core - automaticly load products

### DIFF
--- a/src/gui/ProductModel.cpp
+++ b/src/gui/ProductModel.cpp
@@ -6,6 +6,17 @@ ProductModel::ProductModel(QObject *parent)
     // TODO: Get products from core through getAllProducts [currently not available]
 }
 
+void ProductModel::loadAllProducts()
+{
+    beginResetModel();
+    products.clear();
+
+    bakcyl::core::Core core;
+    products = core.getAllProducts();
+
+    endResetModel();
+}
+
 int ProductModel::rowCount(const QModelIndex &parent) const
 {
     // For list models only the root node (an invalid parent) should return the list's size. For all

--- a/src/gui/ProductModel.cpp
+++ b/src/gui/ProductModel.cpp
@@ -3,7 +3,7 @@
 ProductModel::ProductModel(QObject *parent)
     : QAbstractListModel(parent)
 {
-    // TODO: Get products from core through getAllProducts [currently not available]
+    loadAllProducts();
 }
 
 void ProductModel::loadAllProducts()

--- a/src/gui/ProductModel.hpp
+++ b/src/gui/ProductModel.hpp
@@ -26,6 +26,8 @@ public:
 
     virtual QHash<int, QByteArray> roleNames() const override;
 
+    Q_INVOKABLE void loadAllProducts();
+
 private:
     std::vector<bakcyl::common::Product> products;
 

--- a/src/gui/resources/AddProductWindow.qml
+++ b/src/gui/resources/AddProductWindow.qml
@@ -12,6 +12,8 @@ Window {
     visible: true
     title: qsTr("Add new Product")
 
+    onClosing: productModel.loadAllProducts()
+
     DatabaseManager {
         id: databaseManager
     }

--- a/src/gui/resources/AddProductWindow.qml
+++ b/src/gui/resources/AddProductWindow.qml
@@ -12,8 +12,6 @@ Window {
     visible: true
     title: qsTr("Add new Product")
 
-    onClosing: productModel.loadAllProducts()
-
     DatabaseManager {
         id: databaseManager
     }
@@ -229,6 +227,8 @@ Window {
                         productCategoriesField.text,
                         productDescriptionArea.text
                     ) ? successBox.open() : failBox.open()
+
+                    productModel.loadAllProducts()
                 }
             }
         }

--- a/src/gui/resources/ProductList.qml
+++ b/src/gui/resources/ProductList.qml
@@ -6,6 +6,7 @@ import Searchbox 1.0
 import Product 1.0
 
 Frame {
+    property var productModel: productModel
     GridLayout {
         id: productListBaseGrid
         anchors.fill: parent
@@ -65,8 +66,10 @@ Frame {
             clip: true
             spacing: 3
 
-            model: ProductModel { }
-
+            model: ProductModel { 
+                id: productModel 
+            }
+            
             Loader {
                 id: productPageLoader
                 property int productId : 0

--- a/src/gui/resources/main.qml
+++ b/src/gui/resources/main.qml
@@ -16,6 +16,7 @@ Window {
 
     Loader {
         id: addProductWindowLoader
+        property var productModel: productList.productModel
     }
 
     GridLayout {
@@ -77,6 +78,7 @@ Window {
         }
 
         ProductList {
+            id: productList
             Layout.fillHeight: true
             Layout.fillWidth: true
         }


### PR DESCRIPTION
Created a method for ProductModel which gets list of all products from core and restarts the ListView with received data. The function is Q_INVOKABLE - it can be called from qml.

The function is called when ProductModel is created (at application startup) and when AddProductWindow is closed - new product could have been added.

Optimization:
- [x] reloading recurs *always* when the window is closed - even when no changes were made; Possible solution is to reload only when 'confirm' button on form was pressed.

This is a draft because I tested changes on mocked methods of Core, since those methods aren't implemented yet.