### PR TITLE
Dev/gui/connect product instance list to core - autamaticly load product instances

### DIFF
--- a/src/gui/ProductInstanceModel.cpp
+++ b/src/gui/ProductInstanceModel.cpp
@@ -3,7 +3,19 @@
 ProductInstanceModel::ProductInstanceModel(QObject *parent)
     : QAbstractListModel{parent}
 {
-    // TODO: Get productInstances from core throug getProductInstanceByProductId [not available now]
+    // Base product ID is passed by QML, thus loadAllProductInstances() is not called at construction
+}
+
+void ProductInstanceModel::loadAllProductInstances(int baseProdcutId)
+{
+    beginResetModel();
+    productInstances.clear();
+
+    bakcyl::core::Core core;
+    uint32_t productId = static_cast<std::uint32_t>(baseProdcutId);
+    productInstances = core.getProductInstancesByProductID(productId);
+
+    endResetModel();
 }
 
 int ProductInstanceModel::rowCount(const QModelIndex &parent) const

--- a/src/gui/ProductInstanceModel.hpp
+++ b/src/gui/ProductInstanceModel.hpp
@@ -25,6 +25,8 @@ public:
 
     virtual QHash<int, QByteArray> roleNames() const override;
 
+    Q_INVOKABLE void loadAllProductInstances(int baseProdcutId);
+
 private:
     std::vector<bakcyl::common::ProductInstance> productInstances;
 

--- a/src/gui/resources/AddProductInstanceWindow.qml
+++ b/src/gui/resources/AddProductInstanceWindow.qml
@@ -225,6 +225,8 @@ Window {
                         productInstanceLocationField.text,
                         parseInt(productInstanceQuantityField.text)
                     ) ? successBox.open() : failBox.open()
+
+                    productInstanceModel.loadAllProductInstances()
                 }
             }
         }

--- a/src/gui/resources/ProductInstanceList.qml
+++ b/src/gui/resources/ProductInstanceList.qml
@@ -50,8 +50,11 @@ Frame {
             clip: true
             spacing: 3
 
-            model: ProductInstanceModel { }
-
+            model: ProductInstanceModel {
+                id: productInstanceModel
+            }
+            productInstanceModel.loadAllProductInstances(baseProductId)
+            
             delegate: RowLayout {
                 width: parent.width
                 spacing: 5

--- a/src/gui/resources/ProductWindow.qml
+++ b/src/gui/resources/ProductWindow.qml
@@ -134,6 +134,7 @@ Window {
         ProductInstanceList {
             Layout.fillHeight: true
             Layout.fillWidth: true
+            property int parentProductId: baseProductId
         }
     }
 }

--- a/src/gui/resources/ProductWindow.qml
+++ b/src/gui/resources/ProductWindow.qml
@@ -17,6 +17,7 @@ Window {
     Loader {
         id: addProductInstanceWindowLoader
         property int productId
+        property var productInstanceModel: productInstanceList.productInstanceModel
     }
 
     Connections {
@@ -132,6 +133,7 @@ Window {
         }
 
         ProductInstanceList {
+            id: productInstanceList
             Layout.fillHeight: true
             Layout.fillWidth: true
             property int parentProductId: baseProductId


### PR DESCRIPTION
Created a method for ProdcutInstanceModel which takes ID of base product, and loads to model all product instances with such ID. The function is Q_INVOKABLE - it can be called directly from qml. It takes baseProductId as int (in database it's uint32-t) because qml does not support c++ types.

The function to load data is called from qml when model is constructed and when confirm button on 'addProductInstanceWindow' is pressed.

This is a draft because I tested changes on mocked methods of Core, since those methods aren't implemented yet.